### PR TITLE
Fixed build

### DIFF
--- a/assign4.cc
+++ b/assign4.cc
@@ -46,7 +46,7 @@
              // test for proper opening of output file 
              if(!outFile.is_open())
               {
-                 cerr<<"Can't open output file: "<<outFile;
+                 cerr<<"Can't open output file: "<<a4_out<<endl;
                  return FAIL;
                }
 


### PR DESCRIPTION
Today I attempted to build the thing, and I got this error:
```
g++ -c -Wall assign4.cc
assign4.cc: In function ‘int main(int, char**)’:
assign4.cc:49:50: error: no match for ‘operator<<’ (operand types are ‘std::basic_ostream<char>’ and ‘std::ofstream’ {aka ‘std::basic_ofstream<char>’})
   49 |                  cerr<<"Can't open output file: "<<outFile;
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
      |                      |                             |
      |                      std::basic_ostream<char>      std::ofstream {aka std::basic_ofstream<char>}
```